### PR TITLE
Script to build jxcore and jxcore-cordova distribution files.

### DIFF
--- a/build_scripts/build-script-files/jxcore/build_scripts/android_compile.sh
+++ b/build_scripts/build-script-files/jxcore/build_scripts/android_compile.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+
+# Copyright & License details are available under JXCORE_LICENSE file
+
+NORMAL_COLOR='\033[0m'
+RED_COLOR='\033[0;31m'
+GREEN_COLOR='\033[0;32m'
+GRAY_COLOR='\033[0;37m'
+
+LOG() {
+  COLOR="$1"
+  TEXT="$2"
+  echo -e "${COLOR}$TEXT ${NORMAL_COLOR}"
+}
+
+
+ERROR_ABORT() {
+  if [[ $? != 0 ]]
+  then
+    LOG $RED_COLOR "compilation aborted\n"
+    exit  
+  fi
+}
+
+
+ERROR_ABORT_MOVE() {
+  if [[ $? != 0 ]]
+  then
+    $($1)
+    LOG $RED_COLOR "compilation aborted for $2 target\n"
+    exit  
+  fi
+}
+
+if [ $# -eq 0 ]
+then
+  LOG $RED_COLOR "no argument provided."
+  LOG $GREEN_COLOR "usage: android_compile <ndk_path> <optionally --embed-leveldown>\n"
+  exit
+fi
+
+export ANDROID_NDK=$1
+
+CONF_EXTRAS=
+MIPS=0 #out_mipsel_droid
+ARM64=0 #out_arm64_droid
+
+if [ $# -eq 2 ]
+then
+  CONF_EXTRAS=$2
+fi
+
+ARM7=out_arm_droid
+INTEL64=out_x64_droid
+INTEL32=out_ia32_droid
+FATBIN=out_android/android
+    
+MAKE_INSTALL() {
+  TARGET_DIR="out_$1_droid"
+  mv $TARGET_DIR out
+  ./configure --static-library --dest-os=android --dest-cpu=$1 --engine-mozilla --compress-internals $CONF_EXTRAS
+  ERROR_ABORT_MOVE "mv out $TARGET_DIR" $1
+  make V= -j 8
+  ERROR_ABORT_MOVE "mv out $TARGET_DIR" $1
+  
+  PREFIX_DIR="out/Release"
+  $STRIP -d $PREFIX_DIR/libcares.a
+  mv $PREFIX_DIR/libcares.a "$PREFIX_DIR/libcares_$1.a"
+  
+  $STRIP -d $PREFIX_DIR/libchrome_zlib.a
+  mv $PREFIX_DIR/libchrome_zlib.a "$PREFIX_DIR/libchrome_zlib_$1.a"
+  
+  $STRIP -d $PREFIX_DIR/libhttp_parser.a
+  mv $PREFIX_DIR/libhttp_parser.a "$PREFIX_DIR/libhttp_parser_$1.a"
+  
+  $STRIP -d $PREFIX_DIR/libjx.a
+  mv $PREFIX_DIR/libjx.a "$PREFIX_DIR/libjx_$1.a"
+  
+  $STRIP -d $PREFIX_DIR/libmozjs.a
+  mv $PREFIX_DIR/libmozjs.a "$PREFIX_DIR/libmozjs_$1.a"
+  
+  $STRIP -d $PREFIX_DIR/libopenssl.a
+  mv $PREFIX_DIR/libopenssl.a "$PREFIX_DIR/libopenssl_$1.a"
+  
+  $STRIP -d $PREFIX_DIR/libuv.a
+  mv $PREFIX_DIR/libuv.a "$PREFIX_DIR/libuv_$1.a"
+  
+  $STRIP -d $PREFIX_DIR/libsqlite3.a
+  mv $PREFIX_DIR/libsqlite3.a "$PREFIX_DIR/libsqlite3_$1.a"
+  
+if [ "$CONF_EXTRAS" == "--embed-leveldown" ]
+then
+  $STRIP -d $PREFIX_DIR/libleveldown.a
+  mv $PREFIX_DIR/libleveldown.a "$PREFIX_DIR/libleveldown_$1.a"
+  
+  $STRIP -d $PREFIX_DIR/libsnappy.a
+  mv $PREFIX_DIR/libsnappy.a "$PREFIX_DIR/libsnappy_$1.a"
+  
+  $STRIP -d $PREFIX_DIR/libleveldb.a
+  mv $PREFIX_DIR/libleveldb.a "$PREFIX_DIR/libleveldb_$1.a"
+fi
+  
+  mv out $TARGET_DIR
+}
+
+COMBINE() {
+if [ $MIPS != 0 ]
+then
+  mv "$MIPS/Release/$1_mipsel.a" "$FATBIN/bin/"
+fi
+if [ $ARM64 != 0 ]
+then
+  mv "$ARM64/Release/$1_arm64.a" "$FATBIN/bin/"
+fi
+  mv "$ARM7/Release/$1_arm.a" "$FATBIN/bin/"
+  mv "$INTEL64/Release/$1_x64.a" "$FATBIN/bin/"
+  mv "$INTEL32/Release/$1_ia32.a" "$FATBIN/bin/"
+  ERROR_ABORT
+}
+
+if [ $MIPS != 0 ]
+then
+  mkdir out_mipsel_droid
+fi
+
+if [ $ARM64 != 0 ]
+then
+  mkdir out_arm64_droid
+fi
+
+mkdir out_arm_droid
+mkdir out_x64_droid
+mkdir out_ia32_droid
+mkdir out_android
+
+rm -rf out
+
+OLD_PATH=$PATH
+if [ $MIPS != 0 ]
+then
+  export TOOLCHAIN=$PWD/android-toolchain-mipsel
+  export PATH=$TOOLCHAIN/bin:$OLD_PATH
+  export AR=mipsel-linux-android-ar
+  export CC=mipsel-linux-android-gcc
+  export CXX=mipsel-linux-android-g++
+  export LINK=mipsel-linux-android-g++
+  export STRIP=mipsel-linux-android-strip
+
+  LOG $GREEN_COLOR "Compiling Android MIPS\n"
+  MAKE_INSTALL mipsel
+fi
+
+if [ $ARM64 != 0 ]
+then
+  export TOOLCHAIN=$PWD/android-toolchain-arm64
+  export PATH=$TOOLCHAIN/bin:$OLD_PATH
+  export AR=aarch64-linux-android-ar
+  export CC=aarch64-linux-android-gcc
+  export CXX=aarch64-linux-android-g++
+  export LINK=aarch64-linux-android-g++
+  export STRIP=aarch64-linux-android-strip
+
+  LOG $GREEN_COLOR "Compiling Android ARM64\n"
+  MAKE_INSTALL arm64
+fi
+
+export TOOLCHAIN=$PWD/android-toolchain-arm
+export PATH=$TOOLCHAIN/bin:$OLD_PATH
+export AR=arm-linux-androideabi-ar
+export CC=arm-linux-androideabi-gcc
+export CXX=arm-linux-androideabi-g++
+export LINK=arm-linux-androideabi-g++
+export STRIP=arm-linux-androideabi-strip
+
+LOG $GREEN_COLOR "Compiling Android ARM7\n"
+MAKE_INSTALL arm
+
+export TOOLCHAIN=$PWD/android-toolchain-intelx64
+export PATH=$TOOLCHAIN/bin:$OLD_PATH
+export AR=x86_64-linux-android-ar
+export CC=x86_64-linux-android-gcc
+export CXX=x86_64-linux-android-g++
+export LINK=x86_64-linux-android-g++
+export STRIP=x86_64-linux-android-strip
+
+LOG $GREEN_COLOR "Compiling Android INTEL64\n"
+MAKE_INSTALL x64
+
+export TOOLCHAIN=$PWD/android-toolchain-intel
+export PATH=$TOOLCHAIN/bin:$OLD_PATH
+export AR=i686-linux-android-ar
+export CC=i686-linux-android-gcc
+export CXX=i686-linux-android-g++
+export LINK=i686-linux-android-g++
+export STRIP=i686-linux-android-strip
+
+LOG $GREEN_COLOR "Compiling Android INTEL32\n"
+MAKE_INSTALL ia32
+
+LOG $GREEN_COLOR "Preparing FAT binaries\n"
+rm -rf $FATBIN
+mkdir -p $FATBIN/bin
+
+COMBINE "libcares"
+COMBINE "libchrome_zlib"
+COMBINE "libhttp_parser"
+COMBINE "libjx"
+COMBINE "libmozjs"
+COMBINE "libopenssl"
+COMBINE "libuv"
+COMBINE "libsqlite3"
+
+if [ "$CONF_EXTRAS" == "--embed-leveldown" ]
+then
+  COMBINE "libleveldown"
+  COMBINE "libsnappy"
+  COMBINE "libleveldb"
+fi
+
+cp src/public/*.h $FATBIN/bin
+
+LOG $GREEN_COLOR "JXcore Android binaries are ready under $FATBIN\n"

--- a/build_scripts/build-script-files/jxcore/build_scripts/android_compile.sh
+++ b/build_scripts/build-script-files/jxcore/build_scripts/android_compile.sh
@@ -2,6 +2,13 @@
 
 # Copyright & License details are available under JXCORE_LICENSE file
 
+# The compile scripts for Android and iOS that are present in the jxcore repo
+# have the "-j 2" make flag hard-coded, it makes sense for the travis build
+# since in travis the build machines have only 2 cores available. In order to
+# avoid to make changes in two repos it was safer and quicker to just copy
+# those files over here and change them to optimize the compilation for desktop
+# CPUs (i.e. "-j 8").
+
 NORMAL_COLOR='\033[0m'
 RED_COLOR='\033[0;31m'
 GREEN_COLOR='\033[0;32m'

--- a/build_scripts/build-script-files/jxcore/build_scripts/ios_compile.sh
+++ b/build_scripts/build-script-files/jxcore/build_scripts/ios_compile.sh
@@ -2,6 +2,13 @@
 
 # Copyright & License details are available under JXCORE_LICENSE file
 
+# The compile scripts for Android and iOS that are present in the jxcore repo
+# have the "-j 2" make flag hard-coded, it makes sense for the travis build
+# since in travis the build machines have only 2 cores available. In order to
+# avoid to make changes in two repos it was safer and quicker to just copy
+# those files over here and change them to optimize the compilation for desktop
+# CPUs (i.e. "-j 8").
+
 NORMAL_COLOR='\033[0m'
 RED_COLOR='\033[0;31m'
 GREEN_COLOR='\033[0;32m'

--- a/build_scripts/build-script-files/jxcore/build_scripts/ios_compile.sh
+++ b/build_scripts/build-script-files/jxcore/build_scripts/ios_compile.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# Copyright & License details are available under JXCORE_LICENSE file
+
+NORMAL_COLOR='\033[0m'
+RED_COLOR='\033[0;31m'
+GREEN_COLOR='\033[0;32m'
+GRAY_COLOR='\033[0;37m'
+
+ARM7=out_ios/arm
+ARM7s=out_ios/armv7s
+ARM64=out_ios/arm64
+INTEL64=out_ios/x64
+INTEL32=out_ios/ia32
+FATBIN=out_ios/ios
+
+LOG() {
+  COLOR="$1"
+  TEXT="$2"
+  echo -e "${COLOR}$TEXT ${NORMAL_COLOR}"
+}
+
+
+ERROR_ABORT() {
+  if [[ $? != 0 ]]
+  then
+    LOG $RED_COLOR "compilation aborted\n"
+    exit	
+  fi
+}
+
+
+ERROR_ABORT_MOVE() {
+  if [[ $? != 0 ]]
+  then
+    $($1)
+    LOG $RED_COLOR "compilation aborted for $2 target\n"
+	exit	
+  fi
+}
+
+NO_STRIP=0
+if [[ $1 == "--no-strip" ]]
+then
+  NO_STRIP=1
+elif [[ $2 == "--no-strip" ]]
+then
+  NO_STRIP=1
+fi
+
+CONF_EXTRAS=
+
+if [[ $1 == "--embed-leveldown" ]]
+then
+  CONF_EXTRAS="--embed-leveldown"
+elif [[ $2 == "--embed-leveldown" ]]
+then
+  CONF_EXTRAS="--embed-leveldown"
+fi
+
+
+MAKE_INSTALL() {
+  TARGET_DIR="out_$1_ios"
+  PREFIX_DIR="out_ios/$1"
+  mv $TARGET_DIR out
+  ./configure --prefix=$PREFIX_DIR --static-library --dest-os=ios --dest-cpu=$1 --engine-mozilla --compress-internals $CONF_EXTRAS
+  ERROR_ABORT_MOVE "mv out $TARGET_DIR" $1
+  rm -rf $PREFIX_DIR/bin
+  make V= -j 8 install
+  ERROR_ABORT_MOVE "mv out $TARGET_DIR" $1
+  mv out $TARGET_DIR
+	
+  mv $PREFIX_DIR/bin/libcares.a "$PREFIX_DIR/bin/libcares_$1.a"
+  mv $PREFIX_DIR/bin/libchrome_zlib.a "$PREFIX_DIR/bin/libchrome_zlib_$1.a"
+  mv $PREFIX_DIR/bin/libhttp_parser.a "$PREFIX_DIR/bin/libhttp_parser_$1.a"
+  mv $PREFIX_DIR/bin/libjx.a "$PREFIX_DIR/bin/libjx_$1.a"
+  mv $PREFIX_DIR/bin/libmozjs.a "$PREFIX_DIR/bin/libmozjs_$1.a"
+  mv $PREFIX_DIR/bin/libopenssl.a "$PREFIX_DIR/bin/libopenssl_$1.a"
+  mv $PREFIX_DIR/bin/libuv.a "$PREFIX_DIR/bin/libuv_$1.a"
+  mv $PREFIX_DIR/bin/libsqlite3.a "$PREFIX_DIR/bin/libsqlite3_$1.a"
+  
+  if [ "$CONF_EXTRAS" == "--embed-leveldown" ]
+  then
+    mv $TARGET_DIR/Release/libleveldown.a "$PREFIX_DIR/bin/libleveldown_$1.a"
+    mv $TARGET_DIR/Release/libsnappy.a "$PREFIX_DIR/bin/libsnappy_$1.a"
+    mv $TARGET_DIR/Release/libleveldb.a "$PREFIX_DIR/bin/libleveldb_$1.a"
+  fi
+  rm $TARGET_DIR/Release/*.a
+}
+
+
+MAKE_FAT() {
+  if [[ $NO_STRIP == 0 ]]
+  then
+    strip -x "$ARM64/bin/$1_arm64.a"
+    strip -x "$ARM7/bin/$1_arm.a"
+    strip -x "$ARM7s/bin/$1_armv7s.a"
+    strip -x "$INTEL64/bin/$1_x64.a"
+    strip -x "$INTEL32/bin/$1_ia32.a"
+  fi
+  
+  lipo -create "$ARM64/bin/$1_arm64.a" "$ARM7/bin/$1_arm.a" "$ARM7s/bin/$1_armv7s.a" "$INTEL64/bin/$1_x64.a" "$INTEL32/bin/$1_ia32.a" -output "$FATBIN/bin/$1.a"
+  ERROR_ABORT
+}
+
+
+mkdir out_armv7s_ios
+mkdir out_arm_ios
+mkdir out_arm64_ios
+mkdir out_x64_ios
+mkdir out_ia32_ios
+mkdir out_ios
+
+rm -rf out
+
+LOG $GREEN_COLOR "Compiling IOS INTEL32\n"
+MAKE_INSTALL ia32
+
+LOG $GREEN_COLOR "Compiling IOS ARMv7\n"
+MAKE_INSTALL arm
+
+LOG $GREEN_COLOR "Compiling IOS ARMv7s\n"
+MAKE_INSTALL armv7s
+
+LOG $GREEN_COLOR "Compiling IOS ARM64\n"
+MAKE_INSTALL arm64
+
+LOG $GREEN_COLOR "Compiling IOS INTEL64\n"
+MAKE_INSTALL x64
+ 
+
+LOG $GREEN_COLOR "Preparing FAT binaries\n"
+rm -rf $FATBIN
+mkdir -p $FATBIN/bin
+mv $ARM7/include $FATBIN/
+
+cp deps/mozjs/src/js.msg $FATBIN/include/node/
+
+MAKE_FAT "libcares"
+MAKE_FAT "libchrome_zlib"
+MAKE_FAT "libhttp_parser"
+MAKE_FAT "libjx"
+MAKE_FAT "libmozjs"
+MAKE_FAT "libopenssl"
+MAKE_FAT "libuv"
+MAKE_FAT "libsqlite3"
+if [ "$CONF_EXTRAS" == "--embed-leveldown" ]
+then
+  MAKE_FAT "libleveldown"
+  MAKE_FAT "libleveldb"
+  MAKE_FAT "libsnappy"
+fi
+
+cp src/public/*.h $FATBIN/bin
+
+rm -rf $ARM7s
+rm -rf $ARM7
+rm -rf $ARM64
+rm -rf $INTEL32
+rm -rf $INTEL64
+
+LOG $GREEN_COLOR "JXcore iOS binaries are ready under $FATBIN"

--- a/build_scripts/macos-build-dist.sh
+++ b/build_scripts/macos-build-dist.sh
@@ -120,7 +120,12 @@ else
 fi
 # -----------------------------------------------------------------------------
 # 4-Checkout branch and update build scripts
-# TODO: get checkout release branch
+# The compile scripts for Android and iOS that are present in the jxcore repo
+# have the "-j 2" make flag hard-coded, it makes sense for the travis build
+# since in travis the build machines have only 2 cores available. In order to
+# avoid to make changes in two repos it was safer and quicker to just copy
+# those files over here and change them to optimize the compilation for desktop
+# CPUs (i.e. "-j 8").
 if [ $EXEC_FROM -gt "4" ]
 then
     LOG $NORMAL_COLOR "Skipping step 4."

--- a/build_scripts/macos-build-dist.sh
+++ b/build_scripts/macos-build-dist.sh
@@ -1,0 +1,331 @@
+#!/bin/bash
+# This script builds the jxcore and the jxcore-cordova distribution files
+# It runs on macOS with the latest XCode preinstalled.
+# It downloads the Android NDK, it clones the jxcore and jxcore-cordova 
+# repositories and it builds all the required files but the NPM modules
+
+BUILD_DIR="$PWD"
+EXEC_FROM="0"
+
+# Log files
+LOG_STDOUT="$BUILD_DIR/log-stdout"
+LOG_STDERR="$BUILD_DIR/log-stderr"
+LOG_ZIP="$BUILD_DIR/log-zip"
+
+# Android NDK version
+NDK_VER="r11c"
+NDK_URL="http://dl.google.com/android/repository/android-ndk-"$NDK_VER"-darwin-x86_64.zip"
+
+# Branches to build
+JXCORE_BRANCH="master"
+JXCORE_CORDOVA_BRANCH="master"
+
+NORMAL_COLOR='\033[0m'
+BOLD_COLOR='\033[1m'
+RED_COLOR='\033[0;31m'
+RED_BOLD_COLOR='\033[1;31m'
+GREEN_COLOR='\033[0;32m'
+GRAY_COLOR='\033[0;37m'
+
+LOG() {
+  COLOR="$1"
+  TEXT="$2"
+  echo -e "${COLOR}$TEXT ${NORMAL_COLOR}"
+}
+ABORT() {
+  LOG $RED_COLOR "$1"
+  exit
+}
+ERROR_ABORT() {
+  if [[ $? != 0 ]]
+  then
+    tail log-stderr
+    ABORT "$1"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# 0-Cleanup
+if [ $EXEC_FROM -gt "0" ]
+then
+    LOG $NORMAL_COLOR "Skipping step 0."
+else
+    LOG $NORMAL_COLOR "0-Cleanup..."
+
+    # Remove log files
+    rm -rf log-stdout
+    rm -rf log-stderr
+    rm -rf log-unzip
+
+    # Remove working dirs
+    rm -rf android-ndk
+    rm -rf jxcore-v8
+    rm -rf jxcore-cordova
+    rm -rf jxcore-sm
+    rm -rf jxcore-android
+    rm -rf jxcore-ios
+    rm -rf jxbin
+    rm -rf dist
+fi
+# -----------------------------------------------------------------------------
+# 1-Download android ndk
+if [ $EXEC_FROM -gt "1" ]
+then
+    LOG $NORMAL_COLOR "Skipping step 1."
+else
+    LOG $NORMAL_COLOR "1-Downloding Android NDK..."
+    curl $NDK_URL -o android-ndk.zip
+    ERROR_ABORT "FAILED to download android-ndk"
+
+    LOG $NORMAL_COLOR "1-Unzipping android-ndk..."
+    unzip android-ndk 1>$LOG_ZIP
+    ERROR_ABORT "FAILED to unzip android-ndk"
+
+    mv "android-ndk-"$NDK_VER android-ndk
+    ERROR_ABORT "FAILED to rename android-ndk dir"
+
+    rm -rf android-ndk.zip
+    cd android-ndk
+    export PATH=$PATH:$(pwd)
+fi
+# -----------------------------------------------------------------------------
+# 2-Clone jxcore repo
+if [ $EXEC_FROM -gt "2" ]
+then
+    LOG $NORMAL_COLOR "Skipping step 2."
+else
+    cd $BUILD_DIR
+    LOG $NORMAL_COLOR "2-Cloning jxcore..."
+    git clone https://github.com/ThaliProject/jxcore.git jxcore-v8
+    ERROR_ABORT "FAILED to clone jxcore"
+
+    cd jxcore-v8
+    LOG $NORMAL_COLOR "2-Cloning jxcore submodules..."
+    git submodule init && git submodule update
+    ERROR_ABORT "FAILED to update submodule"
+fi
+# -----------------------------------------------------------------------------
+# 3-Clone jxcore-cordova repo
+if [ $EXEC_FROM -gt "3" ]
+then
+    LOG $NORMAL_COLOR "Skipping step 3."
+else
+    cd $BUILD_DIR
+    LOG $NORMAL_COLOR "3-Cloning jxcore-cordova..."
+    git clone https://github.com/ThaliProject/jxcore-cordova.git jxcore-cordova
+    ERROR_ABORT "FAILED to clone jxcore-cordova"
+
+    cd jxcore-cordova
+    mkdir -p bin
+fi
+# -----------------------------------------------------------------------------
+# 4-Checkout branch and update build scripts
+# TODO: get checkout release branch
+if [ $EXEC_FROM -gt "4" ]
+then
+    LOG $NORMAL_COLOR "Skipping step 4."
+else
+    cd $BUILD_DIR/jxcore-v8
+    git checkout $JXCORE_BRANCH
+    ERROR_ABORT "FAILED to checkout branch $JXCORE_BRANCH"
+    cd ..
+
+    LOG $NORMAL_COLOR "4-Copying android and ios build scripts..."
+    cp build-script-files/jxcore/build_scripts/android_compile.sh jxcore-v8/build_scripts/
+    ERROR_ABORT "FAILED to copy android script"
+
+    cp build-script-files/jxcore/build_scripts/ios_compile.sh jxcore-v8/build_scripts/
+    ERROR_ABORT "FAILED to copy ios script"
+fi
+# -----------------------------------------------------------------------------
+# 5-Duplicate jxcore folder
+if [ $EXEC_FROM -gt "5" ]
+then
+    LOG $NORMAL_COLOR "Skipping step 5."
+else
+    cd $BUILD_DIR
+    LOG $NORMAL_COLOR "5-Creating 'jxcore-sm' dir..."
+    cp -R jxcore-v8/ jxcore-sm/
+    ERROR_ABORT "FAILED to copy 'jxcore-sm' dir"
+
+    LOG $NORMAL_COLOR "5-Creating 'jxcore-android' dir..."
+    cp -R jxcore-v8/ jxcore-android/
+    ERROR_ABORT "FAILED to copy 'jxcore-android' dir"
+
+    LOG $NORMAL_COLOR "5-Creating 'jxcore-ios' dir..."
+    cp -R jxcore-v8/ jxcore-ios/
+    ERROR_ABORT "FAILED to copy 'jxcore-ios' dir"
+fi
+# -----------------------------------------------------------------------------
+# 6-Build jxcore-v8
+if [ $EXEC_FROM -gt "6" ]
+then
+    LOG $NORMAL_COLOR "Skipping step 6."
+else
+    LOG $NORMAL_COLOR "6-Bulding jxcore-v8..."
+    cd $BUILD_DIR/jxcore-v8
+    ./configure --embed-leveldown --debug 1>>$LOG_STDOUT 2>>$LOG_STDERR
+    make V= -j 8 1>>$LOG_STDOUT 2>>$LOG_STDERR
+    ERROR_ABORT "FAILED to compile jxcore-v8"
+fi
+# -----------------------------------------------------------------------------
+# 7-Build jxcore-sm
+if [ $EXEC_FROM -gt "7" ]
+then
+    LOG $NORMAL_COLOR "Skipping step 7."
+else
+    LOG $NORMAL_COLOR "7-Bulding jxcore-sm..."
+    cd $BUILD_DIR/jxcore-sm
+    ./configure --engine-mozilla --embed-leveldown --debug 1>>$LOG_STDOUT 2>>$LOG_STDERR
+    make V= -j 8 1>>$LOG_STDOUT 2>>$LOG_STDERR
+    ERROR_ABORT "FAILED to compile jxcore-sm"
+fi
+# -----------------------------------------------------------------------------
+# 8-Create macOS X dist
+if [ $EXEC_FROM -gt "8" ]
+then
+    LOG $NORMAL_COLOR "Skipping step 8."
+else
+    LOG $NORMAL_COLOR "8-Creating macOS X dist files..."
+    cd $BUILD_DIR
+    mkdir -p dist/jxcore/Release/jx_osx64v8
+    cp jxcore-v8/out/Release/jx dist/jxcore/Release/jx_osx64v8/
+    ERROR_ABORT "FAILED to copy jx_osx64v8 release"
+
+    mkdir -p dist/jxcore/Release/jx_osx64sm
+    cp jxcore-sm/out/Release/jx dist/jxcore/Release/jx_osx64sm/
+    ERROR_ABORT "FAILED to copy jx_osx64sm release"
+
+    cd dist/jxcore/Release
+    zip jx_osx64v8 jx_osx64v8/jx 1>>$LOG_ZIP
+    ERROR_ABORT "FAILED to zip jx_osx64v8 release"
+    rm -rf jx_osx64v8
+
+    zip jx_osx64sm jx_osx64sm/jx 1>>$LOG_ZIP
+    ERROR_ABORT "FAILED to zip jx_osx64sm release"
+    rm -rf jx_osx64sm
+
+    cd $BUILD_DIR
+    mkdir -p dist/jxcore/Debug/jx_osx64v8
+    cp jxcore-v8/out/Debug/jx dist/jxcore/Debug/jx_osx64v8/
+    ERROR_ABORT "FAILED to copy jx_osx64v8 debug"
+
+    mkdir -p dist/jxcore/Debug/jx_osx64sm
+    cp jxcore-sm/out/Debug/jx dist/jxcore/Debug/jx_osx64sm/
+    ERROR_ABORT "FAILED to copy jx_osx64sm debug"
+
+    cd dist/jxcore/Debug
+    zip jx_osx64v8 jx_osx64v8/jx 1>>$LOG_ZIP
+    ERROR_ABORT "FAILED to zip jx_osx64v8 debug"
+    rm -rf jx_osx64v8
+
+    zip jx_osx64sm jx_osx64sm/jx 1>>$LOG_ZIP
+    ERROR_ABORT "FAILED to zip jx_osx64sm debug"
+    rm -rf jx_osx64sm
+
+    cd $BUILD_DIR
+    mkdir jxbin
+    cp jxcore-v8/out/Release/jx jxbin/
+    cd jxbin
+    export PATH=$PATH:$(pwd)
+    cd ..
+    jx -jxv
+    ERROR_ABORT "FAILED to run jx -jxv"
+
+    jx -jsv
+    ERROR_ABORT "FAILED to run jx -jsv"
+fi
+# -----------------------------------------------------------------------------
+# 9-Build jxcore-ios
+if [ $EXEC_FROM -gt "9" ]
+then
+    LOG $NORMAL_COLOR "Skipping step 9."
+else
+    LOG $NORMAL_COLOR "9-Bulding jxcore-ios..."
+    cd $BUILD_DIR/jxcore-ios
+    ./build_scripts/ios_compile.sh --embed-leveldown 1>>$LOG_STDOUT 2>>$LOG_STDERR
+    ERROR_ABORT "FAILED to build jxcore-ios"
+fi
+# -----------------------------------------------------------------------------
+# 10-Create ios dist
+if [ $EXEC_FROM -gt "10" ]
+then
+    LOG $NORMAL_COLOR "Skipping step 10."
+else
+    LOG $NORMAL_COLOR "10-Creating iOS dist files..."
+    cd $BUILD_DIR/jxcore-ios/out_ios/ios/bin
+    zip ../../../../jx_iosFATsm * 1>>$LOG_ZIP
+    ERROR_ABORT "FAILED to zip jxcore-ios"
+    cd ../../../..
+
+    cp jx_iosFATsm.zip jxcore-cordova/bin/ios.zip
+    ERROR_ABORT "FAILED to copy jx_iosFATsm.zip to jxcore-cordova/bin/ios.zip"
+
+    mv jx_iosFATsm.zip dist/jxcore/Release/
+    ERROR_ABORT "FAILED to move jx_iosFATsm.zip to dist/jxcore/Release/"
+fi
+# -----------------------------------------------------------------------------
+# 11-Build jxcore-android
+if [ $EXEC_FROM -gt "11" ]
+then
+    LOG $NORMAL_COLOR "Skipping step 11."
+else
+    LOG $NORMAL_COLOR "11-Configuring jxcore-android..."
+    cd $BUILD_DIR/jxcore-android
+    build_scripts/android-configure.sh ../android-ndk/ 1>>$LOG_STDOUT 2>>$LOG_STDERR
+    ERROR_ABORT "FAILED to configure jxcore-android"
+
+    LOG $NORMAL_COLOR "11-Bulding jxcore-android..."
+    build_scripts/android_compile.sh ../android-ndk/ --embed-leveldown 1>>$LOG_STDOUT 2>>$LOG_STDERR
+    ERROR_ABORT "FAILED to build jxcore-android"
+fi
+# -----------------------------------------------------------------------------
+# 12-Create ios dist
+if [ $EXEC_FROM -gt "12" ]
+then
+    LOG $NORMAL_COLOR "Skipping step 12."
+else
+    LOG $NORMAL_COLOR "12-Creating Android dist files..."
+    cd $BUILD_DIR/jxcore-android/out_android/android/bin
+    zip ../../../../jx_androidFATsm * 1>>$LOG_ZIP
+    ERROR_ABORT "FAILED to zip jxcore-android"
+    cd ../../../..
+    mv jx_androidFATsm.zip dist/jxcore/Release/
+    ERROR_ABORT "FAILED to move jx_androidFATsm.zip to dist/jxcore/Release/"
+fi
+# -----------------------------------------------------------------------------
+# 13-Build jxcore-cordova
+if [ $EXEC_FROM -gt "13" ]
+then
+    LOG $NORMAL_COLOR "Skipping step 13."
+else
+    LOG $NORMAL_COLOR "13-Bulding jxcore-cordova plugin..."
+    cd $BUILD_DIR/jxcore-cordova/
+    git checkout $JXCORE_CORDOVA_BRANCH
+    ERROR_ABORT "FAILED to checkout branch $JXCORE_CORDOVA_BRANCH"
+
+    cd src/android
+    ./build_leveldown.sh ../../../jxcore-android/out_android/android/bin/
+    ERROR_ABORT "FAILED to build jxcore-cordova"
+fi
+# -----------------------------------------------------------------------------
+# 14-Create jxcore-cordova dist
+if [ $EXEC_FROM -gt "14" ]
+then
+    LOG $NORMAL_COLOR "Skipping step ."
+else
+    LOG $NORMAL_COLOR "14-Creating jxcore-cordova pluging dist files..."
+    cd $BUILD_DIR
+    mkdir -p dist/jxcore-cordova/Release/
+    cd jxcore-cordova
+    jx compile io.jxcore.node.jxp 1>>$LOG_STDOUT 2>>$LOG_STDERR
+    ERROR_ABORT "FAILED to compile io.jxcore.node.jxp"
+
+    cp io.jxcore.node.jx ../dist/jxcore-cordova/Release/
+    ERROR_ABORT "FAILED to copy io.jxcore.node.jx to ../dist/jxcore-cordova/Release/"
+fi
+# -----------------------------------------------------------------------------
+# Done
+cd $BUILD_DIR
+ls -lR dist/
+LOG $NORMAL_COLOR "Done."

--- a/builddoc.md
+++ b/builddoc.md
@@ -2,13 +2,21 @@
 
 This covers the build and package of the following:
 
-* JxCore - desktop
-* JxCore - iOS
-* JxCore - Android
-* jxcore-cordova plugin
+* JxCore desktop
+* JxCore iOS
+* JxCore Android
+* JxCore-Cordova plugin
     * this ingests the iOS & Android builds from above...
 
-# Overall Steps
+# Automated scripts
+
+In the build_scripts directory, the macos-build-dist.sh script automates the process of building the JxCore and JxCore-Cordova
+distribution files. It runs on macOS and builds all the required files but:
+ - JxCore for Windows
+ - JxCore for Linux
+ - NPM parts
+
+# Manual Steps
 
 ## JxCore - Desktop build
 


### PR DESCRIPTION
build_scripts/build-script-files/jxcore/build_scripts/android_compile.sh 
and
build_scripts/build-script-files/jxcore/build_scripts/ios_compile.sh
are optimized versions to compile at max speed on Core i7 desktop CPUs, duplicating those files here may not be the best solution on the long term, but it was faster and safer compared to change the original files in the jxcore repo (it would have required to change travis.yml as well and coordinate two PRs in two different repos).

The build script currently doesn't build the NPM parts, that is not a priority right now.
